### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Mutiband Lomb-Scargle Periodograms
-==================================
+Multiband Lomb-Scargle Periodograms
+===================================
 This repository contains the source for our multiband periodogram paper.
 It makes use of the [gatspy](http://github.com/jakevdp/gatspy/) package,
 which has been developed concurrently.


### PR DESCRIPTION
There are a couple Google results for "mutiband" but they appear to have been fixed. Hopefully no one is blindly copying the title from the README!